### PR TITLE
build(deps): bump jersey-client version from 3.1.10 to 3.1.11

### DIFF
--- a/babduino/pom.xml
+++ b/babduino/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>3.1.10</version>
+      <version>3.1.11</version>
     </dependency>
     <dependency>
       <groupId>org.twitter4j</groupId>


### PR DESCRIPTION
Updated the org.glassfish.jersey.core:jersey-client dependency from version 3.1.10 to 3.1.11 in pom.xml to include the latest fixes and improvements.

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Readiness checklist
<!-- prettier-ignore-end -->

Please check the boxes below to confirm that you have followed the
required guidelines for contributions:

- [x] If this pull request includes code changes, they were all properly tested. Automated tests were also included where possible.
- [x] If applicable, this pull request includes the relevant documentation for this change.
- [x] If this pull request is related to an existing issue, you can use the same description below but in any case include a [link to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) like `Fixes #ISSUE_NUMBER.` or `Closes #ISSUE_NUMBER.`.
- [x] All the commits in this pull request were squashed into a single commit. That commit is [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification).

<!-- prettier-ignore-start -->
<!-- markdownlint-disable-next-line MD041 -->
## Description
Bump jersey-client version from 3.1.10 to 3.1.11.
<!-- prettier-ignore-end -->
